### PR TITLE
Host <-> Device Protocol

### DIFF
--- a/common/build.zig
+++ b/common/build.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const mod = b.addModule("common", .{
+        .target = target,
+        .optimize = optimize,
+        .root_source_file = b.path("src/root.zig"),
+    });
+
+    const test_exe = b.addTest(.{ .root_module = mod });
+    const run_test = b.addRunArtifact(test_exe);
+    const test_step = b.step("test", "Tests");
+    test_step.dependOn(&run_test.step);
+}

--- a/common/build.zig.zon
+++ b/common/build.zig.zon
@@ -1,0 +1,7 @@
+.{
+    .name = .common,
+    .version = "0.0.1",
+    .minimum_zig_version = "0.15.1",
+    .paths = .{""},
+    .fingerprint = 0xe5ec7051f4302368,
+}

--- a/common/src/root.zig
+++ b/common/src/root.zig
@@ -42,6 +42,13 @@ pub const HostMessage = struct {
         /// Ends the communication with the device; freeing up the host id.
         @"goodbye!",
     };
+
+    pub fn expectsResponse(msg: *const @This()) bool {
+        return switch (msg.content) {
+            .@"are_you_there?", .@"what_time_is_it?" => true,
+            .@"goodbye!" => false,
+        };
+    }
 };
 
 test HostMessage {

--- a/common/src/root.zig
+++ b/common/src/root.zig
@@ -1,0 +1,139 @@
+//! Common messaging to send between the host and the device.
+//!
+//! All messages are serialized into the same format with a
+//! fixed message length. Specific message types that require
+//! longer messages can be split across multiple messages.
+//!
+//! Serialized messages start with a magic byte 0x01 for host
+//! messages and 0x02 for device messages. Multiple users is a
+//! non-goal. All messages end with 0xFF.
+//!
+//! Following this, the content type is encoded in a single byte
+//! which determines how long the rest of the message is. The
+//! recipient _MUST_ know how many bytes and/or messages the
+//! entire message contains. For messages split into multiple parts
+//! this length is indicated in the first message.
+
+const std = @import("std");
+
+/// The version of this protocol.
+pub const VERSION: u8 = 0;
+/// The maximum length of a message in bytes.
+pub const MAX_MESSAGE_LENGTH: usize = 32;
+pub const SENTINAL: u8 = 0xFF;
+
+// -- Host Message -- //
+
+/// Messages to send _from_ the host to the device.
+pub const HostMessage = struct {
+    /// The content of the message.
+    content: Content,
+
+    pub const MAGIC: u8 = 0x01;
+
+    pub const Content = union(enum(u8)) {
+        /// An initial message sent by the host to be assigned a host id by the device.
+        /// Required to establish communication. The associated data is the version.
+        @"are_you_there?": u8,
+
+        /// Requests the current time as known by the device.
+        @"what_time_is_it?",
+
+        /// Ends the communication with the device; freeing up the host id.
+        @"goodbye!",
+    };
+};
+
+test HostMessage {
+    const msg: HostMessage = .{
+        .content = .{ .@"are_you_there?" = VERSION },
+    };
+
+    const bytes = try serialize(HostMessage, std.testing.allocator, &msg);
+    defer std.testing.allocator.free(bytes);
+
+    const msg2 = try deserialize(HostMessage, bytes);
+
+    try std.testing.expectEqual(msg, msg2);
+}
+
+// -- Device Message -- //
+//
+/// Messages to send _to_ the host from the device.
+pub const DeviceMessage = struct {
+    /// The content of the message.
+    content: Content,
+
+    pub const MAGIC: u8 = 0x02;
+
+    pub const Content = union(enum) {
+        /// A response to the host's "are_you_there?" message.
+        @"i_am_here!",
+
+        /// A response to the host's "what_time_is_it?" message.
+        /// Returns the current time in both ticks along with the timebase frequency.
+        the_time_is: TheTimeIs,
+
+        pub const TheTimeIs = extern struct {
+            ticks: u64,
+            freq: u64,
+        };
+    };
+};
+
+test DeviceMessage {
+    const msg: DeviceMessage = .{
+        .content = .@"i_am_here!",
+    };
+
+    const bytes = try serialize(DeviceMessage, std.testing.allocator, &msg);
+    defer std.testing.allocator.free(bytes);
+
+    const msg2 = try deserialize(DeviceMessage, bytes);
+
+    try std.testing.expectEqual(msg, msg2);
+}
+
+// -- Serialization -- //
+
+pub fn serialize(comptime MessageType: type, allocator: std.mem.Allocator, self: *const MessageType) ![:SENTINAL]u8 {
+    var out = try allocator.allocSentinel(u8, MAX_MESSAGE_LENGTH - 1, SENTINAL);
+    @memset(out, 0);
+
+    out[0] = MessageType.MAGIC;
+    out[1] = @intFromEnum(self.content);
+
+    switch (self.content) {
+        inline else => |content| blk: {
+            if (@TypeOf(content) == void) break :blk;
+            @memcpy(out[2 .. 2 + @sizeOf(@TypeOf(content))], std.mem.asBytes(&content));
+        },
+    }
+
+    return out;
+}
+
+// -- Deserialization -- //
+
+pub fn deserialize(comptime MessageType: type, bytes: [*:SENTINAL]const u8) !MessageType {
+    const slice = std.mem.span(bytes);
+
+    if (slice.len < 2) return error.TooShort;
+    if (slice[0] != MessageType.MAGIC) return error.InvalidMagic;
+
+    inline for (@typeInfo(MessageType.Content).@"union".fields, 0..) |field, i|
+        if (slice[1] == i) {
+            return .{
+                .content = @unionInit(
+                    MessageType.Content,
+                    field.name,
+                    if (field.type == void) {} else std.mem.bytesToValue(
+                        field.type,
+                        slice[2 .. 2 + @sizeOf(field.type)],
+                    ),
+                ),
+            };
+        };
+
+    return error.UnknownContentType;
+}

--- a/host/build.zig
+++ b/host/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .root_source_file = b.path("src/main.zig"),
+        .imports = &.{
+            .{ .name = "common", .module = b.dependency("common", .{}).module("common") },
+        },
+    });
+
+    const exe = b.addExecutable(.{
+        .root_module = mod,
+        .name = "rvhwi",
+    });
+    b.installArtifact(exe);
+
+    const run = b.addRunArtifact(exe);
+    const run_step = b.step("run", "");
+    run_step.dependOn(&run.step);
+}

--- a/host/build.zig.zon
+++ b/host/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .kernel,
+    .name = .host,
     .version = "0.0.1",
     .dependencies = .{
         .common = .{
@@ -9,5 +9,5 @@
     },
     .minimum_zig_version = "0.15.1",
     .paths = .{""},
-    .fingerprint = 0x5dd29aab81b0500f,
+    .fingerprint = 0xcf2713fdf19ae71a,
 }

--- a/host/src/main.zig
+++ b/host/src/main.zig
@@ -1,0 +1,317 @@
+const builtin = @import("builtin");
+
+const std = @import("std");
+const common = @import("common");
+
+// -- Actions & Commands -- //
+
+/// Actions that a command expects to be performed.
+const Action = union(enum) {
+    /// Sends a message to the device. If the message expects a response, blocks until
+    /// it is recieved or the `RecvTimeout` is hit.
+    SendMessage: struct {
+        /// The message to send.
+        message: common.HostMessage,
+        /// What to do with the response, if there is one.
+        callback: RecvCallback = defaultRecvCallback,
+
+        /// The maximum time we wait to recieve a message back from the device.
+        pub const RecvTimeout = 0.1;
+        /// How to respond to the recieved message.
+        pub const RecvCallback = *const fn (common.DeviceMessage) CommandError!void;
+
+        /// A RecvCallback implementation that discards the message.
+        pub fn defaultRecvCallback(message: common.DeviceMessage) CommandError!void {
+            std.log.debug("Recieved message: {any}", .{message});
+        }
+    },
+    /// Quits the application.
+    Quit,
+    /// Do nothing.
+    NoOp,
+};
+
+/// Errors that a command could respond with.
+const CommandError = error{
+    /// The command was not found.
+    NotFound,
+};
+
+/// Commands implementations.
+const Commands = struct {
+    const Command = struct {
+        func: *const fn (*Args) CommandError!Action,
+        brief: []const u8,
+        help: []const u8,
+
+        const Args = std.mem.TokenIterator(u8, .scalar);
+    };
+
+    const COMMAND_MAP: std.StaticStringMap(Command) = blk: {
+        const decls = @typeInfo(@This()).@"struct".decls;
+
+        var kvs: []const struct { []const u8, Command } = &.{};
+        for (decls) |decl| {
+            if (std.mem.eql(u8, "process", decl.name)) continue;
+            var names = std.mem.splitScalar(u8, decl.name, ' ');
+            while (names.next()) |name| {
+                kvs = kvs ++ .{.{
+                    name, Command{
+                        .func = @field(@This(), decl.name),
+                        .brief = @field(@This(), "BRIEF_" ++ decl.name),
+                        .help = @field(@This(), "HELP_" ++ decl.name),
+                    },
+                }};
+            }
+        }
+
+        break :blk .initComptime(kvs);
+    };
+
+    pub fn process(raw_cmd: []const u8) CommandError!Action {
+        if (raw_cmd.len == 0) return Action.NoOp;
+
+        std.log.debug("Processing command '{s}'.", .{raw_cmd});
+
+        var cmd = std.mem.tokenizeScalar(u8, raw_cmd, ' ');
+        const command = COMMAND_MAP.get(cmd.next().?) orelse return error.NotFound;
+        return command.func(&cmd);
+    }
+
+    // -- Implementations -- //
+
+    // Manual Send Message
+
+    const @"BRIEF_send s": []const u8 =
+        "(DEBUG) Manually sends a message to the device.";
+
+    const @"HELP_send s": []const u8 =
+        \\Manually sends a message to the device. This should only be used when
+        \\debugging as higher-level commands properly compose messages together.
+        \\If the message expects a reponse, the responses is printed out.
+        \\
+        \\Usage: (s)end <message-type> [message-data-field=data...]
+        \\
+        \\Required Arguments:
+        \\    message-type - The type of the message. Must be one of:
+        \\        TODO: Convert to a function to generate dynamically.
+        \\
+        \\Optional Arguments:
+        \\    message-data-field - A key-value argument, seperated by an '=', for
+        \\        messages that require additional data. For information on the fields
+        \\        on each message, see 'help send <message-type>' (TODO).
+        \\
+    ;
+
+    pub fn @"send s"(_: *Command.Args) CommandError!Action {
+        return .{
+            .SendMessage = .{
+                .message = .{
+                    .content = .{
+                        .@"are_you_there?" = common.VERSION,
+                    },
+                },
+            },
+        };
+    }
+
+    // Help
+
+    const @"BRIEF_help h ?": []const u8 =
+        "Prints out all available commands or help on an individual command";
+
+    const @"HELP_help h ?": []const u8 =
+        \\When supplied with a command identifier, prints out the full help for that
+        \\command if available. Otherwise, prints out the available commands and
+        \\a brief description of each.
+        \\
+        \\Usage: (help|?) [command]
+        \\
+        \\Optional Arguments:
+        \\    command - The command to print help for (if available)
+        \\
+    ;
+
+    pub fn @"help h ?"(args: *Command.Args) CommandError!Action {
+        if (args.next()) |alias| {
+            if (COMMAND_MAP.get(alias)) |command| {
+                std.debug.print("{s}\n", .{command.help});
+            } else {
+                return error.NotFound;
+            }
+        } else {
+            const message = comptime getAvailableCommandsMessage();
+            std.debug.print(message, .{});
+        }
+
+        return .NoOp;
+    }
+
+    fn getAvailableCommandsMessage() []const u8 {
+        var message: []const u8 =
+            \\Available Commands:
+            \\
+        ;
+
+        const decls = @typeInfo(@This()).@"struct".decls;
+        inline for (decls) |decl| {
+            if (std.mem.eql(u8, "process", decl.name)) continue;
+
+            message = message ++ "\t";
+            var names = std.mem.splitScalar(u8, decl.name, ' ');
+            while (names.next()) |name| {
+                message = message ++ name;
+                if (names.peek() != null) message = message ++ ", ";
+            }
+
+            message = message ++ " - " ++ @field(@This(), "BRIEF_" ++ decl.name) ++ "\n";
+        }
+
+        return message;
+    }
+
+    // Quit
+
+    const @"BRIEF_quit q": []const u8 =
+        "Quits the program";
+
+    const @"HELP_quit q": []const u8 =
+        \\Quits the program.
+        \\
+        \\Usage: (q)uit
+        \\
+    ;
+
+    pub fn @"quit q"(_: *Command.Args) CommandError!Action {
+        return Action.Quit;
+    }
+};
+
+// -- Main -- //
+
+/// The maximum number of bytes read from stdin at once.
+const MAXIMUM_COMMAND_LENGTH = 2048;
+
+const MAX_SOCKET_CONNECTION_ATTEMPTS = std.math.maxInt(usize);
+const SOCKET_CONNECTION_DELAY = std.time.ns_per_s;
+const UART_SOCKET_PATH = "/tmp/rvhw.uart.sock";
+
+pub fn main() !void {
+    var debug_allocator = std.heap.DebugAllocator(.{}).init;
+
+    const gpa, const is_debug = switch (builtin.mode) {
+        .Debug, .ReleaseSafe => .{ debug_allocator.allocator(), true },
+        .ReleaseFast, .ReleaseSmall => .{ std.heap.smp_allocator, false },
+    };
+    defer if (is_debug) {
+        _ = debug_allocator.deinit();
+    };
+
+    var arena_instance = std.heap.ArenaAllocator.init(gpa);
+    defer arena_instance.deinit();
+    const arena = arena_instance.allocator();
+
+    var uart_stream: std.net.Stream = undefined;
+
+    var connection_attempts: usize = 0;
+    while (connection_attempts < MAX_SOCKET_CONNECTION_ATTEMPTS) {
+        uart_stream = std.net.connectUnixSocket(UART_SOCKET_PATH) catch |e| {
+            std.log.err("[{}/{}] Failed to connect to UART socket! Error: {}", .{
+                connection_attempts,
+                MAX_SOCKET_CONNECTION_ATTEMPTS,
+                e,
+            });
+            std.log.info("Retrying in {D}...", .{SOCKET_CONNECTION_DELAY});
+            std.Thread.sleep(SOCKET_CONNECTION_DELAY);
+            connection_attempts += 1;
+            continue;
+        };
+        break;
+    } else {
+        std.log.err("Maximum connection attempts hit! Exiting...", .{});
+        return;
+    }
+
+    std.log.info("Connected to UART socket \"{s}\".", .{UART_SOCKET_PATH});
+    defer uart_stream.close();
+
+    var uart_reader_buf: [1024]u8 = undefined;
+    var uart_writer_buf: [1024]u8 = undefined;
+
+    var uart_reader = uart_stream.reader(&uart_reader_buf);
+    var uart_writer = uart_stream.writer(&uart_writer_buf);
+    const uart_reader_in: *std.Io.Reader = uart_reader.interface();
+    const uart_writer_in: *std.Io.Writer = &uart_writer.interface;
+
+    var stdout = std.fs.File.stdout().writerStreaming(&.{});
+    var stdin = std.fs.File.stdin().readerStreaming(&.{});
+
+    var buf: [MAXIMUM_COMMAND_LENGTH]u8 = undefined;
+    var buf_in: std.Io.Writer = .fixed(&buf);
+
+    var uart_buf: [common.MAX_MESSAGE_LENGTH - 1:common.SENTINAL]u8 = undefined;
+    var uart_buf_in: std.Io.Writer = .fixed(&uart_buf);
+
+    while (stdin.interface.stream(&buf_in, .limited(MAXIMUM_COMMAND_LENGTH))) |n| {
+        if (n > 0) blk: {
+            const cmd = std.mem.trim(u8, buf[0..n], &std.ascii.whitespace);
+            const action = Commands.process(cmd) catch |e| {
+                std.log.err("Command returned an error: {}", .{e});
+                break :blk;
+            };
+
+            sw: switch (action) {
+                .SendMessage => |payload| {
+                    const bytes = try common.serialize(common.HostMessage, arena, &payload.message);
+                    std.log.debug("Sending serialized message {any} to the device.", .{bytes});
+                    _ = uart_writer_in.write(bytes) catch unreachable;
+                    uart_writer_in.flush() catch |e| {
+                        std.log.err("Failed to send message over UART! Error: {}", .{e});
+                        break :sw;
+                    };
+
+                    if (payload.message.expectsResponse()) {
+                        uart_buf_in.end = 0;
+                        while (uart_reader_in.takeByte()) |b| {
+                            if (b == common.DeviceMessage.MAGIC) {
+                                std.log.debug("Read magic byte from UART.", .{});
+                                uart_buf_in.writeByte(b) catch {};
+                                break;
+                            } else {
+                                if (b == 0) continue;
+                                std.log.debug("Discarding byte: {}", .{b});
+                            }
+                        } else |e| {
+                            std.log.err("Error while reading response! Error: {}", .{e});
+                            break :sw;
+                        }
+                        const len = uart_reader_in.stream(&uart_buf_in, .limited(common.MAX_MESSAGE_LENGTH - 2)) catch |e| {
+                            std.log.err("Error while reading response after magic! Error: {}", .{e});
+                            break :sw;
+                        };
+                        if (len != common.MAX_MESSAGE_LENGTH - 2) {
+                            std.log.err("Recieved incomplete message ({} bytes)!", .{len + 1});
+                            break :sw;
+                        }
+
+                        std.log.debug("Recieved response: '{s}' ({any})", .{ uart_buf, uart_buf });
+
+                        const response = common.deserialize(common.DeviceMessage, @ptrCast(&uart_buf)) catch |e| {
+                            std.log.err("Failed to deserialize recieved message: {}", .{e});
+                            break :sw;
+                        };
+                        std.log.debug("Deserialized message: {any}", .{response});
+                    }
+                },
+                .Quit => {
+                    std.log.info("Goodbye!", .{});
+                    break;
+                },
+                .NoOp => {},
+            }
+        }
+
+        buf_in.end = 0;
+        _ = try stdout.interface.write("\n> ");
+    } else |e| return e;
+}

--- a/kernel/build.zig
+++ b/kernel/build.zig
@@ -27,6 +27,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .code_model = .medany,
         .strip = false,
+        .imports = &.{
+            .{ .name = "common", .module = b.dependency("common", .{}).module("common") },
+        },
     });
     mod.addImport("options", options.createModule());
 
@@ -60,11 +63,17 @@ pub fn build(b: *std.Build) void {
             "1G",
             "-device",
             "virtio-vga", // VGA over PCI
+            "-chardev",
+            "socket,id=uart0,path=/tmp/rvhw.uart.sock,server=on,wait=off",
+            "-serial",
+            "chardev:uart0",
             "-kernel",
         });
         cmd.addFileArg(b.path("zig-out/bin/kernel.elf"));
 
-        if (nographic) cmd.addArg("-nographic");
+        if (nographic) {
+            cmd.addArg("-nographic");
+        }
         if (gdb) {
             cmd.addArg("-gdb");
             cmd.addArg(b.fmt("tcp::{}", .{gdb_port}));


### PR DESCRIPTION
Having gone from a basic riscv64 kernel to explore the ISA, to an on-device kernel for hardware introspection, I think I've finally determined the proper direction for the project. When developing the interactive behavior of the on-device UART interaction, it was frankly a headache to have to both parse the incoming bytes and properly display them to whatever serial output I was using. 

Along with the headache, it just wasn't a smart decision to do that sort of work on the device itself. As such, I decided to shift the project towards having a pair of programs: the kernel running on the device (`rvhwk`), and a REPL running on another host (`rvhwi`). This both alleviated the headache and removes significant limitations with the previous approach (mostly output-wise).

The host and device still communicate over UART, but instead with a structured protocol. Fixed-length messages are sent between the two programs, with the host always initiating the conversations, and significantly eases the runtime cost on the kernel and the amount of data sent over UART.

This PR implements:
- The initial protocol, with a limited subset of the future messages.
- A REPL (`rvhwi`) to be run on the host that communicates with QEMU's UART with a unix socket.
- The kernel constantly publishing a specific message to validate `rvhwi`.

There is significant room for improvement in all components of the project, but a few of the most pertinent ones I see from writing this PR are:
- Supporting variable-length messages.
  - While we do indicate the start and end of messages with a magic byte (currently unique for device and host messages, which they don't need to be) and a sentinel byte, `rvhwi` doesn't have "good enough" parsing logic to handle variable-length messages (nor does the common (de)serializer support it).
- Reworking how the REPL commands are created and comptime.
  - While cool, I quite dislike the "thrown-together-ness" of finding prefixed declarations of another. A more sensible approach would be to properly encapsulate commands into their own structs.
- And more stuff I can't think of right now...  